### PR TITLE
Add `playback rate` controls to the MediaPlayer API

### DIFF
--- a/jpro-media/src/main/java/one/jpro/media/player/MediaPlayer.java
+++ b/jpro-media/src/main/java/one/jpro/media/player/MediaPlayer.java
@@ -139,30 +139,6 @@ public interface MediaPlayer extends MediaEngine, EventTarget {
     BooleanProperty autoPlayProperty();
 
     /**
-     * Retrieves the muteProperty value.
-     *
-     * @return the mute setting
-     */
-    boolean isMute();
-
-    /**
-     * Sets the muteProperty value.
-     *
-     * @param value the mute setting
-     */
-    void setMute(boolean value);
-
-    /**
-     * Whether the player audio is muted. A value of <code>true</code> indicates
-     * that audio is <i>not</i> being produced. The value of this property has
-     * no effect on {@link #volumeProperty volume}, i.e., if the audio is muted and then
-     * unmuted, audio playback will resume at the same audible level provided
-     * of course that the <code>volume</code> property has not been modified
-     * meanwhile. The default value is <code>false</code>.
-     */
-    BooleanProperty muteProperty();
-
-    /**
      * Retrieves the current player status.
      *
      * @return the playback {@link Status}
@@ -206,6 +182,66 @@ public interface MediaPlayer extends MediaEngine, EventTarget {
     void setVolume(double value);
 
     DoubleProperty volumeProperty();
+
+    /**
+     * Retrieves the muteProperty value.
+     *
+     * @return the mute setting
+     */
+    boolean isMute();
+
+    /**
+     * Sets the muteProperty value.
+     *
+     * @param value the mute setting
+     */
+    void setMute(boolean value);
+
+    /**
+     * Whether the player audio is muted. A value of <code>true</code> indicates
+     * that audio is <i>not</i> being produced. The value of this property has
+     * no effect on {@link #volumeProperty volume}, i.e., if the audio is muted and then
+     * unmuted, audio playback will resume at the same audible level provided
+     * of course that the <code>volume</code> property has not been modified
+     * meanwhile. The default value is <code>false</code>.
+     */
+    BooleanProperty muteProperty();
+
+    /**
+     * Retrieves the playback rate.
+     * @return the playback rate
+     */
+    double getRate();
+
+    /**
+     * Sets the playback rate to the supplied value. Its effect will be clamped
+     * to the range <code>[0.0,&nbsp;8.0]</code>.
+     * Invoking this method will have no effect if media duration is {@link Duration#INDEFINITE}.
+     * @param value the playback rate
+     */
+    void setRate(double value);
+
+    /**
+     * The rate at which the media should be played. For example, a rate of
+     * <code>1.0</code> plays the media at its normal (encoded) playback rate,
+     * <code>2.0</code> plays back at twice the normal rate, etc. The currently
+     * supported range of rates is <code>[0.0,&nbsp;8.0]</code>. The default
+     * value is <code>1.0</code>.
+     */
+    DoubleProperty rateProperty();
+
+    /**
+     * Retrieves the current playback rate.
+     * @return the current rate
+     */
+    double getCurrentRate();
+
+    /**
+     * The current rate of playback regardless of settings. For example, if
+     * <code>rate</code> is set to 1.0 and the player is paused or stalled,
+     * then <code>currentRate</code> will be zero.
+     */
+    ReadOnlyDoubleProperty currentRateProperty();
 
     /**
      * Retrieves the current media time.

--- a/jpro-media/src/main/java/one/jpro/media/player/MediaPlayer.java
+++ b/jpro-media/src/main/java/one/jpro/media/player/MediaPlayer.java
@@ -15,56 +15,58 @@ import one.jpro.media.player.impl.FXMediaPlayer;
 import one.jpro.media.player.impl.WebMediaPlayer;
 
 /**
- * The MediaPlayer provides functionality to easily play media, both on
- * desktop/mobile and web platforms.
+ * The MediaPlayer offers functionalities for media playback
+ * across desktop/mobile and web platforms with ease.
  * <p>
- * This class provides the controls for playing media.
- * It is used in combination with the {@link MediaSource} and {@link MediaView}
- * classes to display and control media playback. <code>MediaPlayer</code> does
- * not contain any visual elements so must be used in combination with the
- * {@link MediaView} class to view any video track which may be present.
+ * This class equips the user with controls for managing media.
+ * It is typically utilized with the {@link MediaSource} and {@link MediaView}
+ * classes to control and display media playback. Since <code>MediaPlayer</code>
+ * doesn't incorporate any visual elements, it should be used with the
+ * {@link MediaView} class to view any present video track.
  *
- * <p><code>MediaPlayer</code> provides the {@link #play()}, {@link #pause()},
- * {@link #stop()} and {@link #seek(javafx.util.Duration) seek()} controls
- * as playback functionalities. It also provides the {@link #muteProperty mute}
- * and {@link #volumeProperty volume} properties which control audio playback
- * characteristics. Use the {@link #statusProperty status} property to
- * determine the current status of the <code>MediaPlayer</code> and
- * {@link #currentTimeProperty currentTime} property to determine the current
- * time position of the media.
+ * <p><code>MediaPlayer</code> includes {@link #play()}, {@link #pause()},
+ * {@link #stop()}, and {@link #seek(javafx.util.Duration) seek()} controls
+ * for playback functionalities. It also supports the {@link #rateProperty rate}
+ * and {@link #autoPlayProperty autoPlay} properties applicable to all media types.
+ * The class provides the {@link #muteProperty mute} and {@link #volumeProperty volume}
+ * properties to manage audio playback characteristics. The {@link #statusProperty status}
+ * property can be used to ascertain the current status of the <code>MediaPlayer</code>,
+ * and the {@link #currentTimeProperty currentTime} property helps determine the current
+ * time position of the media. The playback rate can be adjusted using the
+ * {@link #rateProperty rate} property, while the {@link #currentRateProperty currentRate}
+ * property offers information about the current rate during playback.
  *
- * <p>For finite duration media, playback may be positioned at any point in time
+ * <p>For media with a finite duration, playback can be positioned at any point in time
  * between <code>0.0</code> and the duration of the media. <code>MediaPlayer</code>
- * refines this definition by adding the {@link #startTimeProperty startTime} and
+ * further refines this by adding the {@link #startTimeProperty startTime} and
  * {@link #stopTimeProperty stopTime}
- * properties which in effect define a virtual media source with time position
- * constrained to <code>[startTime,stopTime]</code>. Media playback
- * commences at <code>startTime</code> and continues to <code>stopTime</code>.
- * The interval defined by these two endpoints is termed a <i>cycle</i> with
- * duration being the difference of the stop and start times. This cycle
- * may be set to repeat a specific or indefinite number of times. The total
- * duration of media playback is then the product of the cycle duration and the
+ * properties, thereby defining a virtual media source with time position
+ * constrained between <code>[startTime,stopTime]</code>. Media playback
+ * starts at <code>startTime</code> and continues till <code>stopTime</code>.
+ * The interval specified by these two endpoints is termed a <i>cycle</i>, with
+ * duration being the difference between the stop and start times. This cycle
+ * can be set to repeat a certain or indefinite number of times. The total
+ * duration of media playback equals the product of the cycle duration and the
  * number of times the cycle is played. If the stop time of the cycle is reached
- * and the cycle is to be played again, the event handler registered with the
+ * and the cycle is set to be played again, the event handler registered with the
  * {@link #onRepeatProperty onRepeat} property is invoked. If the stop time is
  * reached, then the event handler registered with the {@link #onEndOfMediaProperty onEndOfMedia}
- * property is invoked regardless of whether the cycle is to be repeated or not.
- * A zero-relative index of which cycle is presently being played is maintained
+ * property is invoked regardless of whether the cycle is set to be repeated or not.
+ * A zero-relative index of the currently playing cycle is maintained
  * by {@link #currentCountProperty currentCount}.
  * </p>
  *
  * <p>All operations of a <code>MediaPlayer</code> are inherently asynchronous.
- * When the given <code>MediaSource</code> is loaded, use the {@link #setOnReady(EventHandler)}
- * to get notified when the <code>MediaPlayer</code> is ready to play. Other
+ * Upon loading the given <code>MediaSource</code>, use the {@link #setOnReady(EventHandler)}
+ * to get notified when the <code>MediaPlayer</code> is ready for playback. Other
  * event handlers like {@link #setOnPlaying(EventHandler)}, {@link #setOnPaused(EventHandler)},
- * {@link #setOnStopped(EventHandler)}, {@link #setOnEndOfMedia(EventHandler)} and
+ * {@link #setOnStopped(EventHandler)}, {@link #setOnEndOfMedia(EventHandler)}, and
  * {@link #setOnStalled(EventHandler)} can be used to get notified of the
  * corresponding events.
  *
- * <p>The same <code>MediaPlayer</code> object may be shared among multiple
- * <code>MediaView</code>s. This will not affect the player itself. In
- * particular, the property settings of the view will not have any effect on
- * media playback.</p>
+ * <p>A single <code>MediaPlayer</code> object can be shared among multiple
+ * <code>MediaView</code>s without affecting the player. Specifically, the property settings
+ * of the view don't influence media playback.
  *
  * @see MediaSource
  * @see MediaView

--- a/jpro-media/src/main/java/one/jpro/media/player/impl/FXMediaPlayer.java
+++ b/jpro-media/src/main/java/one/jpro/media/player/impl/FXMediaPlayer.java
@@ -256,6 +256,31 @@ public final class FXMediaPlayer extends BaseMediaPlayer {
     }
 
     @Override
+    public double getRate() {
+        return mediaPlayer.getRate();
+    }
+
+    @Override
+    public void setRate(double value) {
+        mediaPlayer.setRate(value);
+    }
+
+    @Override
+    public DoubleProperty rateProperty() {
+        return mediaPlayer.rateProperty();
+    }
+
+    @Override
+    public double getCurrentRate() {
+        return mediaPlayer.getCurrentRate();
+    }
+
+    @Override
+    public ReadOnlyDoubleProperty currentRateProperty() {
+        return mediaPlayer.currentRateProperty();
+    }
+
+    @Override
     public void play() {
         // If the end of media was reached, seek to the beginning
         // before playing, to mimic the behavior of the Web media


### PR DESCRIPTION
The following requirements are met to implement this feature:

- Add `rate` and `currentRate` JavaFX properties to the JPro MediaPlayer API, so they perfectly match JavaFX MediaPlayer API.
- Implement `rate` and `currentRate` media player controls for both the desktop/mobile and the web.
- Their behaviour should be the same for all platforms.